### PR TITLE
Fix large files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "access_log_parser"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Daniel Mikusa <dmikusa@pivotal.io>"]
 edition = "2018"
 description = "A library of Rust parsers for reading access logs in a strongly-typed way"

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -91,9 +91,9 @@ named!(parse_http_status <&str, http::StatusCode>,
     )
 );
 
-named!(parse_bytes <&str, u32>,
+named!(parse_bytes <&str, u64>,
     flat_map!(alt_complete!(take_until_and_consume!(" ") | rest),
-        alt_complete!(parse_to!(u32) | map!(tag!("-"), |_| 0))
+        alt_complete!(parse_to!(u64) | map!(tag!("-"), |_| 0))
         )
 );
 
@@ -664,6 +664,11 @@ mod tests {
         assert_eq!(parse_bytes("-"), Ok(("", 0)));
         assert_eq!(parse_bytes("- "), Ok(("", 0)));
         assert_eq!(parse_bytes(""), Err(Error(Code("", Alt))));
+    }
+
+    #[test]
+    fn test_parse_bytes_large() {
+        assert_eq!(parse_bytes("8296735593"), Ok(("", 8296735593)));
     }
 
     #[test]


### PR DESCRIPTION
Switch bytes from u32 to u64

Otherwise we fail to parse log lines from large downloads.

Log line in new unit test adapted from production log file.

Branch is based upon previous fix for "empty bytes", because otherwise there would be a conflict.

Feel free to edit in any way.
