### PR TITLE
add CI using GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: Rust tests
+
+on: [push, pull_request]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build application
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test


### PR DESCRIPTION
The CI configuration performs a build and runs all tests.
Looks like this when it runs: https://github.com/striezel-stash/access_log_parser/runs/3295601003?check_suite_focus=true