### PR TITLE
Fixes lint

### DIFF
--- a/src/parsers/core.rs
+++ b/src/parsers/core.rs
@@ -60,7 +60,7 @@ pub(super) fn quoted_dash_or_str<'a, E: ParseError<&'a str> + ContextError<&'a s
 pub(super) fn digits<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
     input: &'a str,
 ) -> IResult<&'a str, &'a str, E> {
-    context("digits", take_while(|c: char| c.is_digit(10)))(input)
+    context("digits", take_while(|c: char| c.is_ascii_digit()))(input)
 }
 
 pub(super) fn ip<'a, E>(input: &'a str) -> IResult<&'a str, IpAddr, E>


### PR DESCRIPTION
- Use `c.is_ascii_digit()` instead of `c.is_digit(10)`

Signed-off-by: Daniel Mikusa <dan@mikusa.com>